### PR TITLE
Add support for Bryophyta's Staff, Tome of Fire, fixed miscalculation, and added high-profit highlighting with choice of gradient highlighting based on profit.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.7.3-SNAPSHOT'
+def runeLiteVersion = '1.7.4-SNAPSHOT'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.6.23'
+def runeLiteVersion = '1.7.3-SNAPSHOT'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/highalchighlight/HighAlcHighlightConfig.java
+++ b/src/main/java/com/highalchighlight/HighAlcHighlightConfig.java
@@ -11,58 +11,58 @@ import java.awt.Color;
 public interface HighAlcHighlightConfig extends Config
 {
 	@ConfigItem(
+		position = 1,
 		keyName = "usingBryo",
 		name = "Using Bryophyta's Staff",
-		description = "Configures if you are using Bryophyta's Staff.",
-		position = 1
+		description = "Configures if you are using Bryophyta's Staff."
 	)
 	default boolean useBryoStaff() {return false;}
 
 	@ConfigItem(
-			keyName = "fireRuneSource",
-			name = "Source of Fire Runes",
-			description = "Configures what source of fire runes you are using.",
-			position = 2
+		position = 2,
+		keyName = "fireRuneSource",
+		name = "Source of Fire Runes",
+		description = "Configures what source of fire runes you are using."
 	)
 	default FireRuneSource fireRuneSource() { return FireRuneSource.STAFF; }
 
 	@ConfigItem(
-			position = 3,
-			keyName = "HighlightColour",
-			name = "Highlight Colour",
-			description = "Highlight colour of profitable items"
+		position = 3,
+		keyName = "HighlightColour",
+		name = "Highlight Colour",
+		description = "Highlight colour of profitable items"
 	)
 	default Color getColour() {return Color.BLUE;}
 
 	@ConfigItem(
-			position = 4,
-			keyName = "highlightUnsellables",
-			name = "Highlight Unsellables",
-			description = "If enabled, highlights items that would make a profit but cannot be sold on the GE"
+		position = 4,
+		keyName = "highlightUnsellables",
+		name = "Highlight Unsellables",
+		description = "If enabled, highlights items that would make a profit but cannot be sold on the GE"
 	)
 	default boolean highlightUnsellables() {return true;}
 
 	@ConfigItem(
-			position = 5,
-			keyName = "highProfitValue",
-			name = "High-Profit Threshold",
-			description = "The starting price for high-profit highlighting."
+		position = 5,
+		keyName = "highProfitValue",
+		name = "High-Profit Threshold",
+		description = "The starting price for high-profit highlighting."
 	)
 	default int highProfitValue() { return 300; }
 
 	@ConfigItem(
-			position = 6,
-			keyName = "highProfitColour",
-			name = "High-Profit Colour",
-			description = "Highlight colour of items that are high-profit."
+		position = 6,
+		keyName = "highProfitColour",
+		name = "High-Profit Colour",
+		description = "Highlight colour of items that are high-profit."
 	)
 	default Color getHighValueColour() {return Color.GREEN;}
 
 	@ConfigItem(
-			position = 7,
-			keyName = "unsellableHighlightColour",
-			name = "Unsellables Colour",
-			description = "Colour to show if Highlight Unsellables is checked"
+		position = 7,
+		keyName = "unsellableHighlightColour",
+		name = "Unsellables Colour",
+		description = "Colour to show if Highlight Unsellables is checked"
 	)
 	default Color getUnsellableColour() {return Color.YELLOW;}
 }

--- a/src/main/java/com/highalchighlight/HighAlcHighlightConfig.java
+++ b/src/main/java/com/highalchighlight/HighAlcHighlightConfig.java
@@ -3,12 +3,29 @@ package com.highalchighlight;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import com.highalchighlight.config.FireRuneSource;
 
 import java.awt.Color;
 
 @ConfigGroup("highalchighlight")
 public interface HighAlcHighlightConfig extends Config
 {
+	@ConfigItem(
+		keyName = "usingBryo",
+		name = "Using Bryophyta's Staff",
+		description = "Configures if you are using Bryophyta's Staff.",
+		position = 1
+	)
+	default boolean useBryoStaff() {return false;}
+
+	@ConfigItem(
+			keyName = "fireRuneSource",
+			name = "Source of Fire Runes",
+			description = "Configures what source of fire runes you are using.",
+			position = 2
+	)
+	default FireRuneSource fireRuneSource() { return FireRuneSource.STAFF; }
+
 	@ConfigItem(
 			position = 3,
 			keyName = "HighlightColour",
@@ -18,15 +35,7 @@ public interface HighAlcHighlightConfig extends Config
 	default Color getColour() {return Color.GREEN;}
 
 	@ConfigItem(
-			position = 1,
-			keyName = "useStaff",
-			name = "Use Fire Staff in calc",
-			description = "If enabled, cost of fire runes is not included in profit calculation"
-	)
-	default boolean useFireStaff() {return true;}
-
-	@ConfigItem(
-			position = 2,
+			position = 4,
 			keyName = "highlightUnsellables",
 			name = "Highlight Unsellables",
 			description = "If enabled, highlights items that would make a profit but cannot be sold on the GE"
@@ -34,7 +43,7 @@ public interface HighAlcHighlightConfig extends Config
 	default boolean highlightUnsellables() {return true;}
 
 	@ConfigItem(
-			position = 3,
+			position = 5,
 			keyName = "unsellableHighlightColour",
 			name = "Unsellables Colour",
 			description = "Colour to show if Highlight Unsellables is checked"

--- a/src/main/java/com/highalchighlight/HighAlcHighlightConfig.java
+++ b/src/main/java/com/highalchighlight/HighAlcHighlightConfig.java
@@ -35,28 +35,28 @@ public interface HighAlcHighlightConfig extends Config
 	default Color getColour() {return Color.BLUE;}
 
 	@ConfigItem(
+			position = 5,
+			keyName = "highProfitValue",
+			name = "High-Profit Threshold",
+			description = "The starting price for high-profit highlighting."
+	)
+	default int highProfitValue() { return 300; }
+
+	@ConfigItem(
+			position = 6,
+			keyName = "highProfitColour",
+			name = "High-Profit Colour",
+			description = "Highlight colour of items that are high-profit."
+	)
+	default Color getHighProfitColour() {return Color.GREEN;}
+
+	@ConfigItem(
 		position = 4,
 		keyName = "highlightUnsellables",
 		name = "Highlight Unsellables",
 		description = "If enabled, highlights items that would make a profit but cannot be sold on the GE"
 	)
 	default boolean highlightUnsellables() {return true;}
-
-	@ConfigItem(
-		position = 5,
-		keyName = "highProfitValue",
-		name = "High-Profit Threshold",
-		description = "The starting price for high-profit highlighting."
-	)
-	default int highProfitValue() { return 300; }
-
-	@ConfigItem(
-		position = 6,
-		keyName = "highProfitColour",
-		name = "High-Profit Colour",
-		description = "Highlight colour of items that are high-profit."
-	)
-	default Color getHighValueColour() {return Color.GREEN;}
 
 	@ConfigItem(
 		position = 7,

--- a/src/main/java/com/highalchighlight/HighAlcHighlightConfig.java
+++ b/src/main/java/com/highalchighlight/HighAlcHighlightConfig.java
@@ -32,7 +32,7 @@ public interface HighAlcHighlightConfig extends Config
 			name = "Highlight Colour",
 			description = "Highlight colour of profitable items"
 	)
-	default Color getColour() {return Color.GREEN;}
+	default Color getColour() {return Color.BLUE;}
 
 	@ConfigItem(
 			position = 4,

--- a/src/main/java/com/highalchighlight/HighAlcHighlightConfig.java
+++ b/src/main/java/com/highalchighlight/HighAlcHighlightConfig.java
@@ -28,22 +28,30 @@ public interface HighAlcHighlightConfig extends Config
 
 	@ConfigItem(
 		position = 3,
+		keyName = "useGradientMode",
+		name = "Gradient Mode",
+		description = "Enabling this setting will cause items to be highlighted in a gradient color from your Highlight Colour to your High-Profit Colour based on profitability."
+	)
+	default boolean useGradientMode() {return true;}
+
+	@ConfigItem(
+		position = 4,
 		keyName = "HighlightColour",
 		name = "Highlight Colour",
 		description = "Highlight colour of profitable items"
 	)
-	default Color getColour() {return Color.BLUE;}
+	default Color getColour() {return Color.WHITE;}
 
 	@ConfigItem(
-			position = 4,
+			position = 5,
 			keyName = "highProfitValue",
 			name = "High-Profit Threshold",
-			description = "The starting price for high-profit highlighting."
+			description = "The price for high-profit highlighting."
 	)
 	default int highProfitValue() { return 300; }
 
 	@ConfigItem(
-			position = 5,
+			position = 6,
 			keyName = "highProfitColour",
 			name = "High-Profit Colour",
 			description = "Highlight colour of items that are high-profit."
@@ -51,7 +59,7 @@ public interface HighAlcHighlightConfig extends Config
 	default Color getHighProfitColour() {return Color.GREEN;}
 
 	@ConfigItem(
-			position = 6,
+			position = 7,
 			keyName = "highlightUnsellables",
 			name = "Highlight Unsellables",
 			description = "If enabled, highlights items that would make a profit but cannot be sold on the GE"
@@ -59,7 +67,7 @@ public interface HighAlcHighlightConfig extends Config
 	default boolean highlightUnsellables() {return true;}
 
 	@ConfigItem(
-		position = 7,
+		position = 8,
 		keyName = "unsellableHighlightColour",
 		name = "Unsellables Colour",
 		description = "Colour to show if Highlight Unsellables is checked"

--- a/src/main/java/com/highalchighlight/HighAlcHighlightConfig.java
+++ b/src/main/java/com/highalchighlight/HighAlcHighlightConfig.java
@@ -44,6 +44,22 @@ public interface HighAlcHighlightConfig extends Config
 
 	@ConfigItem(
 			position = 5,
+			keyName = "highProfitValue",
+			name = "High-Profit Threshold",
+			description = "The starting price for high-profit highlighting."
+	)
+	default int highProfitValue() { return 300; }
+
+	@ConfigItem(
+			position = 6,
+			keyName = "highProfitColour",
+			name = "High-Profit Colour",
+			description = "Highlight colour of items that are high-profit."
+	)
+	default Color getHighValueColour() {return Color.GREEN;}
+
+	@ConfigItem(
+			position = 7,
 			keyName = "unsellableHighlightColour",
 			name = "Unsellables Colour",
 			description = "Colour to show if Highlight Unsellables is checked"

--- a/src/main/java/com/highalchighlight/HighAlcHighlightConfig.java
+++ b/src/main/java/com/highalchighlight/HighAlcHighlightConfig.java
@@ -35,28 +35,28 @@ public interface HighAlcHighlightConfig extends Config
 	default Color getColour() {return Color.BLUE;}
 
 	@ConfigItem(
-		position = 4,
-		keyName = "highlightUnsellables",
-		name = "Highlight Unsellables",
-		description = "If enabled, highlights items that would make a profit but cannot be sold on the GE"
-	)
-	default boolean highlightUnsellables() {return true;}
-
-	@ConfigItem(
-		position = 5,
-		keyName = "highProfitValue",
-		name = "High-Profit Threshold",
-		description = "The starting price for high-profit highlighting."
+			position = 4,
+			keyName = "highProfitValue",
+			name = "High-Profit Threshold",
+			description = "The starting price for high-profit highlighting."
 	)
 	default int highProfitValue() { return 300; }
 
 	@ConfigItem(
-		position = 6,
-		keyName = "highProfitColour",
-		name = "High-Profit Colour",
-		description = "Highlight colour of items that are high-profit."
+			position = 5,
+			keyName = "highProfitColour",
+			name = "High-Profit Colour",
+			description = "Highlight colour of items that are high-profit."
 	)
-	default Color getHighValueColour() {return Color.GREEN;}
+	default Color getHighProfitColour() {return Color.GREEN;}
+
+	@ConfigItem(
+			position = 6,
+			keyName = "highlightUnsellables",
+			name = "Highlight Unsellables",
+			description = "If enabled, highlights items that would make a profit but cannot be sold on the GE"
+	)
+	default boolean highlightUnsellables() {return true;}
 
 	@ConfigItem(
 		position = 7,

--- a/src/main/java/com/highalchighlight/HighAlcHighlightOverlay.java
+++ b/src/main/java/com/highalchighlight/HighAlcHighlightOverlay.java
@@ -36,6 +36,10 @@ public class HighAlcHighlightOverlay extends WidgetItemOverlay
         ProfitStatus profitStatus = checkProfitability(itemId);
         switch (profitStatus)
         {
+            case HIGH_PROFIT:
+                colorToUse = config.getHighValueColour();
+                isProfit = true;
+                break;
             case PROFIT:
                 colorToUse = config.getColour();
                 isProfit = true;
@@ -74,7 +78,10 @@ public class HighAlcHighlightOverlay extends WidgetItemOverlay
             natureRunePrice = (int) Math.ceil(natureRunePrice*0.9375);
         }
 
-        if (gePrice > 0 && haPrice - natureRunePrice - fireRunePrice > gePrice)
+        if (gePrice > 0 && haPrice - natureRunePrice - fireRunePrice > gePrice + config.highProfitValue())
+        {
+            return ProfitStatus.HIGH_PROFIT;
+        } else  if (gePrice > 0 && haPrice - natureRunePrice - fireRunePrice > gePrice)
         {
             return ProfitStatus.PROFIT;
         }

--- a/src/main/java/com/highalchighlight/HighAlcHighlightOverlay.java
+++ b/src/main/java/com/highalchighlight/HighAlcHighlightOverlay.java
@@ -6,6 +6,8 @@ import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.WidgetItemOverlay;
 
+import com.highalchighlight.config.FireRuneSource;
+
 import javax.inject.Inject;
 import java.awt.Color;
 import java.awt.Graphics2D;
@@ -56,15 +58,27 @@ public class HighAlcHighlightOverlay extends WidgetItemOverlay
     private ProfitStatus checkProfitability(int itemId)
     {
         ItemComposition itemDef = itemManager.getItemComposition(itemId);
-        int natureRunePrice = itemManager.getItemPrice(ItemID.NATURE_RUNE);
+
         int gePrice = itemManager.getItemPrice(itemId);
         int haPrice = itemDef.getHaPrice();
-        int fireRuneOffset = config.useFireStaff() ? 0 : itemManager.getItemPrice(ItemID.FIRE_RUNE);
-        if (gePrice > 0 && haPrice - natureRunePrice - fireRuneOffset > gePrice)
+
+        // Only account for the price of fire runes if runes are being used instead of a staff or tome.
+        int fireRunePrice = 0;
+        if (config.fireRuneSource() == FireRuneSource.RUNES) {
+            fireRunePrice = 5 * itemManager.getItemPrice(ItemID.FIRE_RUNE);
+        }
+
+        // If Bryophyta's Staff is in use, decrease cost of nature runes.
+        int natureRunePrice = itemManager.getItemPrice(ItemID.NATURE_RUNE);
+        if (config.useBryoStaff()) {
+            natureRunePrice = (int) Math.ceil(natureRunePrice*0.9375);
+        }
+
+        if (gePrice > 0 && haPrice - natureRunePrice - fireRunePrice > gePrice)
         {
             return ProfitStatus.PROFIT;
         }
-        else if (gePrice == 0 && config.highlightUnsellables() && haPrice - natureRunePrice - fireRuneOffset > 0)
+        else if (gePrice == 0 && config.highlightUnsellables() && haPrice - natureRunePrice - fireRunePrice > 0)
         {
             return ProfitStatus.UNSELLABLE_PROFIT;
         }

--- a/src/main/java/com/highalchighlight/HighAlcHighlightOverlay.java
+++ b/src/main/java/com/highalchighlight/HighAlcHighlightOverlay.java
@@ -37,7 +37,7 @@ public class HighAlcHighlightOverlay extends WidgetItemOverlay
         switch (profitStatus)
         {
             case HIGH_PROFIT:
-                colorToUse = config.getHighValueColour();
+                colorToUse = config.getHighProfitColour();
                 isProfit = true;
                 break;
             case PROFIT:

--- a/src/main/java/com/highalchighlight/ProfitStatus.java
+++ b/src/main/java/com/highalchighlight/ProfitStatus.java
@@ -1,8 +1,0 @@
-package com.highalchighlight;
-
-public enum ProfitStatus {
-    HIGH_PROFIT,
-    PROFIT,
-    UNSELLABLE_PROFIT,
-    LOSS
-}

--- a/src/main/java/com/highalchighlight/ProfitStatus.java
+++ b/src/main/java/com/highalchighlight/ProfitStatus.java
@@ -1,6 +1,7 @@
 package com.highalchighlight;
 
 public enum ProfitStatus {
+    HIGH_PROFIT,
     PROFIT,
     UNSELLABLE_PROFIT,
     LOSS

--- a/src/main/java/com/highalchighlight/config/FireRuneSource.java
+++ b/src/main/java/com/highalchighlight/config/FireRuneSource.java
@@ -1,0 +1,20 @@
+package com.highalchighlight.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum FireRuneSource {
+    STAFF("Fire Staff"),
+    TOME("Tome of Fire"),
+    RUNES("Fire Runes");
+
+    private final String name;
+
+    @Override
+    public String toString()
+    {
+        return name;
+    }
+}


### PR DESCRIPTION
Added support for Bryophyta's staff (1/15 chance of not using nature rune).

Changed the "Using Fire Staff" config to instead be a menu with Fire Staff, Tome of Fire, and Fire Rune. 

The original calculation for fire rune cost didn't take into account that it takes 5 fire runes to cast High Alch.

Added Gradient Mode along with a High-Profit value config.
If Gradient Mode is off, items which is greater than the high-profit value will display in the High-Profit Color.
If Gradient Mode is on, items are colored on a gradient from the Highlight color to the High-Profit Color. This allows the user to quickly glance into their bank and find the items that are most profitable to alch. Gradient Mode is on by default.

Default highlight color has been changed to white, Default High-Profit color is Green. To create an easy to see default gradient.
![2021-03-24 19_48_27-RuneLite - Atroxide](https://user-images.githubusercontent.com/546362/112402141-f7e98400-8cd9-11eb-8f7f-32a894d773d1.png)

![2021-03-24 19_49_05-RuneLite - Atroxide](https://user-images.githubusercontent.com/546362/112402185-0b94ea80-8cda-11eb-847a-3764f4922be9.png)

